### PR TITLE
Fix Non-Interval Downloads After an Interval Download

### DIFF
--- a/pluradl.py
+++ b/pluradl.py
@@ -43,7 +43,8 @@ def set_playlist_options(digits):
 
     n = len(digits)
     if n == 0:
-        pass
+        PDL_OPTS.pop("playliststart", None)
+        PDL_OPTS.pop("playlistend", None)
     elif n == 1:
         print("Downloading video indicies up to",digits[0],"to")
         PDL_OPTS["playlistend"]   = digits[0]


### PR DESCRIPTION
Fix a bug causing only partial downloads to occur for non-interval
courses listed after an interval/range-limited course.

E.g., the following courselist.txt would cause only videos 5-10 of both
course-1 and course-2 to download, instead of 5-10 of course-1 and all
of course-2:

```
course-1 5 10
course-2
```

Fixes #41 