### PR TITLE
[#36] Increase Safety of Moving Course Files

### DIFF
--- a/pluradl.py
+++ b/pluradl.py
@@ -69,11 +69,13 @@ def move_content(pdl, course_id, coursepath, completionpath):
     pdl.to_stdout("Moving content to " + finalpath)
     set_directory(completionpath)
     try:
-        if os.path.exists(finalpath):
-            shutil.rmtree(finalpath)
-        shutil.move(coursepath,finalpath)
-        if os.path.exists(INPROGRESSPATH):
-            shutil.rmtree(INPROGRESSPATH)
+        os.makedirs(finalpath)
+        for completed_file in os.listdir(coursepath):
+            final_file = os.path.join(finalpath, completed_file)
+            if os.path.exists(final_file):
+                shutil.rmtree(final_file)
+            shutil.move(os.path.join(coursepath, completed_file), final_file)
+        shutil.rmtree(coursepath)
     except PermissionError:
         print("Directory still in use, leaving it. Will be fixed in future releases.")
 


### PR DESCRIPTION
Modify the move_content function so that instead of completely replacing
the target directory with the source directory, it moves the files
inside the source directory and then removes the directory. This
prevents file loss when a subset of files have been downloaded after
another completed subset.

Do not delete the INPROGRESSPATH afterwards, in case there are other
course folders inside.

Fixes #36